### PR TITLE
Corregir fallo de url de cabina

### DIFF
--- a/decide/booth/urls.py
+++ b/decide/booth/urls.py
@@ -5,5 +5,5 @@ from .views import BoothView, BoothUrlView, InicioView
 urlpatterns = [
     path('<int:voting_id>/', BoothView.as_view()),
     path('<voting_url>/', BoothUrlView.as_view()),
-    path('inicio/', InicioView.as_view(), name="boothInicio")
+    path('', InicioView.as_view(), name="boothInicio")
 ]


### PR DESCRIPTION
Corregido fallo por el cual  al añadir la funcionalidad
de url personalizada entraba en conflicto con la url
de la página de inicio de cabina