### PR TITLE
Arreglar error en inicio de cabina y nuevos tests unitarios

### DIFF
--- a/decide/booth/selenium/test_inicio_sin_logear.py
+++ b/decide/booth/selenium/test_inicio_sin_logear.py
@@ -18,5 +18,5 @@ class TestTestiniciosinlogear(StaticLiveServerTestCase):
     self.driver.quit()
 
   def test_test_inicio_sin_logear(self):
-    self.driver.get("http://localhost:8000/booth/inicio/")
+    self.driver.get("http://localhost:8000/booth/")
     self.driver.find_element(By.ID, "alertButton").click()

--- a/decide/booth/templates/booth/inicio.html
+++ b/decide/booth/templates/booth/inicio.html
@@ -51,7 +51,7 @@
                                             {% if votacion.end_date != None %}
                                                 <p>Fecha de finalización: {{votacion.end_date}}</p>
                                             {% endif %}
-                                            {% if votacion.start_date != None %}
+                                            {% if votacion.start_date != None and votacion.end_date == None%}
                                                 <a href="/booth/{{votacion.id}}">Acceder a la votación</a>
                                             {% endif %}
                                         </div>
@@ -90,11 +90,11 @@
                                             <p>Fecha de comienzo: {{votacion.start_date}}</p>
                                             {% if votacion.end_date == None %}
                                                 <p>Fecha de finalización: Sin finalizar.</p>
+                                                <a href="/booth/{{votacion.id}}">Acceder a la votación</a>
                                             {% endif %}
                                             {% if votacion.end_date != None %}
                                                 <p>Fecha de finalización: {{votacion.end_date}}</p>
                                             {% endif %}
-                                            <a href="/booth/{{votacion.id}}">Acceder a la votación</a>
                                         </div>
                                     </div>
                                 </div>
@@ -110,7 +110,7 @@
 {% if not usuario.id %}
 <div class="alert alert-danger" id="divAlert" role="alert">
     Parece que no has iniciado sesión
-    <a tpye=button href="/admin" class="btn btn-primary" id="alertButton">Login</a>  
+    <a tpye=button href="/admin" class="btn btn-primary" id="alertButton">Login</a>
 </div>
 {% endif %}
 {% endblock %}

--- a/decide/booth/views.py
+++ b/decide/booth/views.py
@@ -82,8 +82,11 @@ class InicioView(TemplateView):
 
         list_noVotados = []
         for v in votaciones:
-            for c in mis_censos:
-                if v.id == c.voting_id and v not in list_votados:
-                    list_noVotados.append(v)
+            if v.poll == True and v not in list_votados:
+                list_noVotados.append(v)
+            else:
+                for c in mis_censos:
+                    if v.id == c.voting_id and v not in list_votados:
+                        list_noVotados.append(v)
 
         return list_votados, list_noVotados

--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -420,3 +420,54 @@ class VotingTestCase(BaseTestCase):
                     list_votados.add(v)
 
         self.assertEquals(list(list_votados)[0], v)
+
+    def test_quick_poll_list_undone(self):
+        v = self.create_quick_poll()
+        self.create_voters(v)
+
+        usuario = list(Census.objects.filter(voting_id=v.id))[0].voter_id
+
+        votaciones = Voting.objects.all()
+        mis_votos = Vote.objects.filter(voter_id=usuario)
+        mis_censos = Census.objects.filter(voter_id=usuario)
+
+        list_votados = set()
+        for v in votaciones:
+            for voto in mis_votos:
+                if voto.voting_id == v.id:
+                    list_votados.add(v)
+
+        list_noVotados = []
+        for v in votaciones:
+            if v.poll == True and v not in list_votados:
+                list_noVotados.append(v)
+            else:
+                for c in mis_censos:
+                    if v.id == c.voting_id and v not in list_votados:
+                        list_noVotados.append(v)
+
+        self.assertEquals(list_noVotados[0], v)
+
+
+    def test_quick_poll_list_done(self):
+        v = self.create_quick_poll()
+        self.create_voters(v)
+
+        v.create_pubkey()
+        v.start_date = timezone.now()
+        v.save()
+
+        usuario = list(Census.objects.filter(voting_id=v.id))[0]
+
+        self.store_concrete_vote(v, usuario)
+
+        votaciones = Voting.objects.all()
+        mis_votos = Vote.objects.filter(voter_id=usuario.voter_id)
+
+        list_votados = set()
+        for v in votaciones:
+            for voto in mis_votos:
+                if voto.voting_id == v.id:
+                    list_votados.add(v)
+
+        self.assertEquals(list(list_votados)[0], v)


### PR DESCRIPTION
Arreglado error por el cual, una encuesta rápida no aparecía en el listado de votaciones sin realizar aunque no fuera necesario estar en el censo. Además, se han añadido tests unitarios para probar esta funcionalidad y corregido un test de selenium.

Closes #49