### PR TITLE
test : Crear test de preguntas #3

### DIFF
--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -531,3 +531,19 @@ class VotingTestCase(BaseTestCase):
 
         self.assertEquals(list(list_votados)[0], v)
 
+    def test_create_rank_order_incorrect(self):
+        # Se introduce rank order con tipo identidad (por defecto), lo cual no está permitido
+        data = {'option_types': '2', 'desc':'descripcion', 'type':'0', 'options-0-number': '1',
+                'options-1-number':'2', 'options-0-option':'opción A', 'options-1-option': 'opcion B'}
+        self.login()
+        response = self.client.put('/admin/voting/question/add/', data, format='json')
+        self.assertEqual(response.status_code, 302) # Se comprueba que redirige en lugar de crear la pregunta
+
+
+    @override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+    def test_create_rank_order(self):
+        data = {'option_types': '1', 'desc':'descripcion', 'type':'0', 'options-0-number': '1',
+                'options-1-number':'2', 'options-0-option':'opción A', 'options-1-option': 'opcion B'}
+        self.login()
+        response = self.client.post('/admin/voting/question/add/', data, follow=True)
+        self.assertEqual(response.status_code, 200) # Se comprueba que da 200 OK, por tanto se crea la pregunta


### PR DESCRIPTION
Implementados tests para comprobar que las preguntas para rank order se deben crear
con el tipo "borda", ya que en caso contrario el formulario debe mostrar un error.